### PR TITLE
Fix GitHub Pages deployment permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    
     steps:
     - uses: actions/checkout@v4
     


### PR DESCRIPTION
## Summary
• Fix 403 permission error during GitHub Pages deployment
• Add explicit permissions for pages deployment job
• Resolve write access issues with gh-pages branch push

## Root Cause
The deployment was failing with:
```
remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/o-shina/how-many-spins.git/': The requested URL returned error: 403
```

## Solution
Added explicit permissions to the deploy job:
- `contents: read` - Read repository contents
- `pages: write` - Write to GitHub Pages
- `id-token: write` - Generate deployment tokens

## Test plan
- [x] CI/CD workflow updated with proper permissions
- [x] Deployment should succeed after merge to main
- [x] No impact on existing test pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)