### PR TITLE
feat: UIデザインリニューアル（グラスモーフィズム対応）

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,19 @@
 import type { Metadata, Viewport } from 'next';
+import { IBM_Plex_Mono, Space_Grotesk } from 'next/font/google';
 import '@/app/globals.css';
+
+const spaceGrotesk = Space_Grotesk({
+  subsets: ['latin'],
+  variable: '--font-space',
+  display: 'swap',
+});
+
+const plexMono = IBM_Plex_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  variable: '--font-plex',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: '地球が何回回った時？ | How Many Spins?',
@@ -27,7 +41,15 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ja">
-      <body className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-green-50 font-sans antialiased">
+      <body
+        className={`${spaceGrotesk.variable} ${plexMono.variable} min-h-screen bg-slate-50 font-sans text-slate-900 antialiased`}
+      >
+        <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+          <div className="absolute -left-32 top-0 h-72 w-72 rounded-full bg-sky-200/40 blur-3xl" />
+          <div className="absolute right-0 top-24 h-80 w-80 rounded-full bg-emerald-200/40 blur-3xl" />
+          <div className="absolute bottom-0 left-1/3 h-72 w-72 rounded-full bg-lime-200/30 blur-3xl" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.12),transparent_55%)]" />
+        </div>
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ export default function HomePage() {
         <Header />
 
         <main className="flex-grow">
-          <div className="container mx-auto max-w-4xl py-8">
+          <div className="container mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
             {/* カウンターコンテナ（リアルタイム/時間指定切り替え） */}
             <section className="mb-12">
               <CounterContainer />

--- a/src/components/CounterContainer.tsx
+++ b/src/components/CounterContainer.tsx
@@ -17,14 +17,14 @@ function CounterContainer() {
     <div className="w-full">
       {/* タブ切り替えUI */}
       <div className="flex justify-center mb-8">
-        <div className="inline-flex rounded-lg border border-gray-300 bg-white p-1 shadow-sm">
+        <div className="inline-flex rounded-full border border-white/70 bg-white/70 p-1 shadow-sm backdrop-blur">
           <button
             onClick={() => setMode('realtime')}
             className={`
-              px-6 py-2.5 text-sm font-medium rounded-md transition-all duration-200
+              px-6 py-2.5 text-sm font-semibold rounded-full transition-all duration-200
               ${mode === 'realtime'
-                ? 'bg-blue-600 text-white shadow-sm'
-                : 'text-gray-700 hover:text-gray-900 hover:bg-gray-50'
+                ? 'bg-gradient-to-r from-sky-500 to-emerald-500 text-white shadow-sm'
+                : 'text-slate-600 hover:text-slate-900 hover:bg-white/70'
               }
             `}
             type="button"
@@ -41,10 +41,10 @@ function CounterContainer() {
           <button
             onClick={() => setMode('datetime')}
             className={`
-              px-6 py-2.5 text-sm font-medium rounded-md transition-all duration-200
+              px-6 py-2.5 text-sm font-semibold rounded-full transition-all duration-200
               ${mode === 'datetime'
-                ? 'bg-blue-600 text-white shadow-sm'
-                : 'text-gray-700 hover:text-gray-900 hover:bg-gray-50'
+                ? 'bg-gradient-to-r from-sky-500 to-emerald-500 text-white shadow-sm'
+                : 'text-slate-600 hover:text-slate-900 hover:bg-white/70'
               }
             `}
             type="button"

--- a/src/components/DateTimeInput.tsx
+++ b/src/components/DateTimeInput.tsx
@@ -209,24 +209,27 @@ function DateTimeInput() {
   if (!formatLoaded) {
     return (
       <div className="text-center py-12">
-        <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mb-4"></div>
-        <p className="text-gray-600">読み込み中...</p>
+        <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-sky-500 mb-4"></div>
+        <p className="text-slate-600">読み込み中...</p>
       </div>
     );
   }
 
   return (
     <div className="w-full max-w-2xl mx-auto px-4">
-      <div className="bg-white rounded-lg shadow-md p-6 md:p-8">
-        <h2 className="text-xl md:text-2xl font-bold text-gray-800 mb-6 text-center">
+      <div className="rounded-2xl border border-white/70 bg-white/80 p-6 shadow-[0_20px_60px_rgba(15,23,42,0.08)] backdrop-blur md:p-8">
+        <h2 className="text-xl md:text-2xl font-semibold text-slate-900 mb-2 text-center">
           指定した日時の地球回転数を計算
         </h2>
+        <p className="text-center text-sm text-slate-500 mb-6">
+          UTCで入力し、地球の累積自転回数を確認できます
+        </p>
 
         {/* 入力フォーム */}
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* 日付入力 */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-3">
+            <label className="block text-sm font-semibold text-slate-700 mb-3">
               日付（UTC）
             </label>
             <div className="flex flex-wrap gap-2 items-center">
@@ -238,7 +241,7 @@ function DateTimeInput() {
                   value={inputValues.year}
                   onChange={(e) => handleInputChange('year', e.target.value)}
                   placeholder="2025"
-                  className="w-24 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-24 rounded-md border border-slate-200/80 bg-white/80 px-3 py-2 text-slate-900 shadow-sm focus:border-slate-300 focus:outline-none focus:ring-2 focus:ring-sky-300"
                   aria-label="年"
                 />
                 <datalist id="year-options">
@@ -246,7 +249,7 @@ function DateTimeInput() {
                     <option key={y} value={y} />
                   ))}
                 </datalist>
-                <span className="ml-1 text-gray-600">年</span>
+                <span className="ml-1 text-slate-600">年</span>
               </div>
               {/* コンボボックス：月 */}
               <div className="flex items-center">
@@ -256,7 +259,7 @@ function DateTimeInput() {
                   value={inputValues.month}
                   onChange={(e) => handleInputChange('month', e.target.value)}
                   placeholder="12"
-                  className="w-16 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-16 rounded-md border border-slate-200/80 bg-white/80 px-3 py-2 text-slate-900 shadow-sm focus:border-slate-300 focus:outline-none focus:ring-2 focus:ring-sky-300"
                   aria-label="月"
                 />
                 <datalist id="month-options">
@@ -264,7 +267,7 @@ function DateTimeInput() {
                     <option key={m} value={m} />
                   ))}
                 </datalist>
-                <span className="ml-1 text-gray-600">月</span>
+                <span className="ml-1 text-slate-600">月</span>
               </div>
               {/* コンボボックス：日 */}
               <div className="flex items-center">
@@ -274,7 +277,7 @@ function DateTimeInput() {
                   value={inputValues.day}
                   onChange={(e) => handleInputChange('day', e.target.value)}
                   placeholder="31"
-                  className="w-16 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-16 rounded-md border border-slate-200/80 bg-white/80 px-3 py-2 text-slate-900 shadow-sm focus:border-slate-300 focus:outline-none focus:ring-2 focus:ring-sky-300"
                   aria-label="日"
                 />
                 <datalist id="day-options">
@@ -282,14 +285,14 @@ function DateTimeInput() {
                     <option key={d} value={d} />
                   ))}
                 </datalist>
-                <span className="ml-1 text-gray-600">日</span>
+                <span className="ml-1 text-slate-600">日</span>
               </div>
             </div>
           </div>
 
           {/* 時刻入力 */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-3">
+            <label className="block text-sm font-semibold text-slate-700 mb-3">
               時刻（UTC）
             </label>
             <div className="flex flex-wrap gap-2 items-center">
@@ -301,7 +304,7 @@ function DateTimeInput() {
                   value={inputValues.hour}
                   onChange={(e) => handleInputChange('hour', e.target.value)}
                   placeholder="23"
-                  className="w-16 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-16 rounded-md border border-slate-200/80 bg-white/80 px-3 py-2 text-slate-900 shadow-sm focus:border-slate-300 focus:outline-none focus:ring-2 focus:ring-sky-300"
                   aria-label="時"
                 />
                 <datalist id="hour-options">
@@ -309,7 +312,7 @@ function DateTimeInput() {
                     <option key={h} value={h} />
                   ))}
                 </datalist>
-                <span className="ml-1 text-gray-600">時</span>
+                <span className="ml-1 text-slate-600">時</span>
               </div>
               {/* コンボボックス：分 */}
               <div className="flex items-center">
@@ -319,7 +322,7 @@ function DateTimeInput() {
                   value={inputValues.minute}
                   onChange={(e) => handleInputChange('minute', e.target.value)}
                   placeholder="59"
-                  className="w-16 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-16 rounded-md border border-slate-200/80 bg-white/80 px-3 py-2 text-slate-900 shadow-sm focus:border-slate-300 focus:outline-none focus:ring-2 focus:ring-sky-300"
                   aria-label="分"
                 />
                 <datalist id="minute-options">
@@ -327,15 +330,15 @@ function DateTimeInput() {
                     <option key={m} value={m} />
                   ))}
                 </datalist>
-                <span className="ml-1 text-gray-600">分</span>
+                <span className="ml-1 text-slate-600">分</span>
               </div>
             </div>
           </div>
 
           {/* エラーメッセージ */}
           {error && (
-            <div className="bg-red-50 border border-red-200 rounded-md p-3">
-              <p className="text-sm text-red-600">{error}</p>
+            <div className="rounded-md border border-rose-200 bg-rose-50 p-3">
+              <p className="text-sm text-rose-600">{error}</p>
             </div>
           )}
 
@@ -344,14 +347,14 @@ function DateTimeInput() {
             <button
               type="submit"
               disabled={isCalculating}
-              className="flex-1 bg-blue-600 text-white px-6 py-3 rounded-md font-medium hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="flex-1 rounded-md bg-gradient-to-r from-sky-500 to-emerald-500 px-6 py-3 font-semibold text-white shadow-sm transition hover:brightness-105 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-transparent disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isCalculating ? '計算中...' : '計算する'}
             </button>
             <button
               type="button"
               onClick={handleClear}
-              className="px-6 py-3 border border-gray-300 text-gray-700 rounded-md font-medium hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors"
+              className="rounded-md border border-slate-300/80 px-6 py-3 font-semibold text-slate-700 transition hover:bg-white/70 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 focus:ring-offset-transparent"
             >
               クリア
             </button>
@@ -360,18 +363,18 @@ function DateTimeInput() {
 
         {/* 計算結果 */}
         {result && (
-          <div className="mt-8 pt-8 border-t border-gray-200">
-            <h3 className="text-lg font-semibold text-gray-800 mb-4 text-center">
+          <div className="mt-8 pt-8 border-t border-slate-200">
+            <h3 className="text-lg font-semibold text-slate-800 mb-4 text-center">
               計算結果
             </h3>
 
             {/* 入力した日時 */}
             <div className="mb-6">
-              <p className="text-sm text-gray-600 mb-2">入力日時:</p>
-              <p className="text-lg font-mono text-gray-800">
+              <p className="text-sm text-slate-600 mb-2">入力日時:</p>
+              <p className="text-lg font-mono text-slate-800">
                 {result.formattedDateTime}
                 {result.isFuture && (
-                  <span className="ml-2 text-sm text-orange-600 font-normal">
+                  <span className="ml-2 text-sm text-amber-600 font-normal">
                     （未来の日時）
                   </span>
                 )}
@@ -379,11 +382,11 @@ function DateTimeInput() {
             </div>
 
             {/* 回転数表示 */}
-            <div className="bg-gradient-to-r from-blue-50 to-green-50 rounded-lg p-6">
-              <p className="text-sm text-gray-600 mb-2 text-center">
+            <div className="rounded-xl border border-white/70 bg-white/80 p-6 shadow-sm">
+              <p className="text-sm text-slate-600 mb-2 text-center">
                 地球の累積自転回数
               </p>
-              <p className="text-3xl md:text-4xl font-bold text-blue-800 font-mono text-center">
+              <p className="text-3xl md:text-4xl font-semibold text-transparent bg-clip-text bg-gradient-to-r from-sky-600 to-emerald-600 font-mono text-center">
                 {formatRotation(result.rotationCount)} 回転
               </p>
             </div>
@@ -394,7 +397,7 @@ function DateTimeInput() {
             </div>
 
             {/* 計算基準の説明 */}
-            <div className="text-xs text-gray-500 mt-4 text-center">
+            <div className="text-xs text-slate-500 mt-4 text-center">
               <p>※ 計算基準: 西暦1年1月1日 00:00 UTC = 0回転</p>
               <p>※ 恒星日（23時間56分4秒）基準で計算</p>
             </div>
@@ -403,7 +406,7 @@ function DateTimeInput() {
       </div>
 
       {/* 使い方の説明 */}
-      <div className="mt-6 text-sm text-gray-600 text-center">
+      <div className="mt-6 text-sm text-slate-600 text-center">
         <p>※ 日時はUTC（協定世界時）で入力してください</p>
         <p>※ 年は1〜9999の範囲で指定可能です</p>
       </div>

--- a/src/components/DisplayFormatToggle.tsx
+++ b/src/components/DisplayFormatToggle.tsx
@@ -15,16 +15,18 @@ function DisplayFormatToggle() {
   }
 
   return (
-    <div className="flex items-center justify-center mb-4">
-      <div className="flex items-center space-x-3">
-        <span className="text-sm font-medium text-gray-600">表示形式:</span>
+    <div className="flex items-center justify-center">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+          表示形式
+        </span>
         <button
           onClick={toggleFormat}
           className={`
-            relative inline-flex h-8 w-16 items-center rounded-full border-2 transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+            relative inline-flex h-8 w-16 items-center rounded-full border-2 transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-transparent
             ${isInteger 
-              ? 'bg-blue-600 border-blue-600' 
-              : 'bg-gray-200 border-gray-300'
+              ? 'bg-slate-900 border-slate-900' 
+              : 'bg-white/70 border-slate-300'
             }
           `}
           type="button"
@@ -41,17 +43,17 @@ function DisplayFormatToggle() {
           />
         </button>
         <div className="flex flex-col text-xs">
-          <span className={`font-medium ${isInteger ? 'text-blue-600' : 'text-gray-400'}`}>
+          <span className={`font-semibold ${isInteger ? 'text-slate-900' : 'text-slate-400'}`}>
             整数
           </span>
-          <span className={`font-medium ${!isInteger ? 'text-blue-600' : 'text-gray-400'}`}>
+          <span className={`font-semibold ${!isInteger ? 'text-slate-900' : 'text-slate-400'}`}>
             小数
           </span>
         </div>
       </div>
       
       {/* 説明テキスト */}
-      <div className="ml-4 text-xs text-gray-500">
+      <div className="ml-4 text-xs text-slate-500">
         {isInteger ? '整数表示（切り捨て）' : '小数表示（6桁精度）'}
       </div>
     </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,16 +9,16 @@ function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="bg-gray-50 border-t border-gray-200 py-6 mt-12">
+    <footer className="mt-12 border-t border-white/70 bg-white/70 py-6 backdrop-blur">
       <div className="container mx-auto px-4 text-center">
-        <div className="space-y-2 text-sm text-gray-600">
+        <div className="space-y-2 text-sm text-slate-600">
           <p>
             <strong>地球が何回回った時？</strong> - How Many Spins?
           </p>
           <p>
             子どもの煽りフレーズに即答するWebアプリケーション
           </p>
-          <div className="flex flex-wrap justify-center gap-4 text-xs">
+          <div className="flex flex-wrap justify-center gap-4 text-xs text-slate-500">
             <span>© {currentYear} How Many Spins</span>
             <span>恒星日基準: 23時間56分4秒</span>
             <span>基準日時: 西暦1年1月1日 00:00 UTC</span>
@@ -26,8 +26,8 @@ function Footer() {
         </div>
         
         {/* 技術情報 */}
-        <div className="mt-4 pt-4 border-t border-gray-200">
-          <p className="text-xs text-gray-500">
+        <div className="mt-4 pt-4 border-t border-white/70">
+          <p className="text-xs text-slate-500">
             Made with Next.js, TypeScript, and Tailwind CSS
           </p>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,14 +7,18 @@ import { memo } from 'react';
  */
 function Header() {
   return (
-    <header className="bg-white shadow-sm border-b border-gray-200 py-4">
-      <div className="container mx-auto px-4">
-        <div className="text-center">
-          <h1 className="text-2xl md:text-4xl font-bold text-gray-800 mb-2">
+    <header className="border-b border-white/70 bg-white/70 backdrop-blur">
+      <div className="container mx-auto px-4 py-6">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 shadow-sm">
+            Live Counter
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+          </span>
+          <h1 className="text-3xl font-semibold tracking-tight text-slate-900 md:text-5xl">
             地球が何回回った時？
           </h1>
-          <p className="text-sm md:text-base text-gray-600">
-            How Many Spins? - 煽りフレーズに即答するWebアプリ
+          <p className="max-w-2xl text-sm text-slate-600 md:text-base">
+            How Many Spins? - 煽りフレーズに即答するための地球回転カウンター
           </p>
         </div>
       </div>

--- a/src/components/MainCounter.tsx
+++ b/src/components/MainCounter.tsx
@@ -76,19 +76,19 @@ function MainCounter() {
   if (isLoading || !formatLoaded) {
     return (
       <div className="text-center py-12">
-        <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mb-4"></div>
-        <p className="text-gray-600">計算中...</p>
+        <div className="inline-block h-8 w-8 animate-spin rounded-full border-b-2 border-sky-500 mb-4"></div>
+        <p className="text-slate-600">計算中...</p>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="text-center py-12 text-red-600">
+      <div className="text-center py-12 text-rose-600">
         <p className="text-lg mb-4">{error}</p>
         <button 
           onClick={updateRotationData}
-          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+          className="px-4 py-2 rounded-md bg-slate-900 text-white hover:bg-slate-800 transition-colors"
         >
           再試行
         </button>
@@ -98,7 +98,7 @@ function MainCounter() {
 
   if (!rotationData) {
     return (
-      <div className="text-center py-12 text-gray-600">
+      <div className="text-center py-12 text-slate-600">
         <p>データを読み込めませんでした</p>
       </div>
     );
@@ -106,41 +106,50 @@ function MainCounter() {
 
   return (
     <div className="text-center py-8 md:py-12">
-      {/* 現在時刻表示 */}
-      <div className="mb-6">
-        <h2 className="text-lg md:text-xl font-semibold text-gray-700 mb-2">
-          現在時刻
-        </h2>
-        <p className="text-xl md:text-2xl font-mono text-gray-800">
-          {rotationData.formattedDateTime}
-        </p>
-      </div>
+      <div className="grid gap-6">
+        {/* 現在時刻表示 */}
+        <div className="rounded-2xl border border-white/70 bg-white/70 p-6 shadow-sm backdrop-blur">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Current Time (UTC)
+          </p>
+          <h2 className="mt-3 text-lg font-semibold text-slate-700 md:text-xl">
+            現在時刻
+          </h2>
+          <p className="mt-2 text-xl font-mono text-slate-900 md:text-2xl">
+            {rotationData.formattedDateTime}
+          </p>
+        </div>
 
-      {/* 地球回転数表示 */}
-      <div className="mb-6">
-        <h2 className="text-lg md:text-xl font-semibold text-gray-700 mb-4">
-          地球の累積自転回数
-        </h2>
-        <div className="bg-gradient-to-r from-blue-50 to-green-50 rounded-lg p-6 md:p-8 mx-4">
-          <p className="text-3xl md:text-5xl lg:text-6xl font-bold text-blue-800 font-mono mb-2">
+        {/* 地球回転数表示 */}
+        <div className="rounded-2xl border border-white/70 bg-white/80 p-6 shadow-[0_20px_60px_rgba(15,23,42,0.08)] backdrop-blur">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Earth Rotation Counter
+          </p>
+          <h2 className="mt-3 text-lg font-semibold text-slate-700 md:text-xl">
+            地球の累積自転回数
+          </h2>
+          <p className="mt-4 text-3xl font-semibold text-transparent bg-clip-text bg-gradient-to-r from-sky-600 to-emerald-600 font-mono md:text-5xl lg:text-6xl animate-counter">
             {formatRotation(rotationData.rotationCount)} 回転
           </p>
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-3 text-xs text-slate-500">
+            <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200/70 bg-emerald-50 px-3 py-1 font-semibold text-emerald-700">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+              リアルタイム更新中
+            </span>
+            <span>恒星日基準で計算</span>
+          </div>
         </div>
       </div>
 
       {/* 表示形式切り替えトグル */}
-      <DisplayFormatToggle />
-
-      {/* 計算基準の説明 */}
-      <div className="text-sm text-gray-500 mt-4">
-        <p>※ 計算基準: 西暦1年1月1日 00:00 UTC = 0回転</p>
-        <p>※ 恒星日（23時間56分4秒）基準で計算</p>
+      <div className="mt-6">
+        <DisplayFormatToggle />
       </div>
 
-      {/* リアルタイム更新インジケーター */}
-      <div className="flex items-center justify-center mt-4 text-xs text-gray-400">
-        <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse mr-2"></div>
-        <span>リアルタイム更新中</span>
+      {/* 計算基準の説明 */}
+      <div className="mt-6 text-xs text-slate-500">
+        <p>※ 計算基準: 西暦1年1月1日 00:00 UTC = 0回転</p>
+        <p>※ 恒星日（23時間56分4秒）基準で計算</p>
       </div>
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,8 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        mono: ['ui-monospace', 'SFMono-Regular', 'Monaco', 'Consolas', 'monospace'],
+        sans: ['var(--font-space)', 'system-ui', 'sans-serif'],
+        mono: ['var(--font-plex)', 'ui-monospace', 'SFMono-Regular', 'Monaco', 'Consolas', 'monospace'],
       },
     },
   },

--- a/test/app/page.test.tsx
+++ b/test/app/page.test.tsx
@@ -76,9 +76,9 @@ describe('HomePage', () => {
 
   test('コンテナの最大幅が設定されていること', () => {
     const { container } = render(<HomePage />);
-    
-    const containerDiv = container.querySelector('.container.mx-auto.max-w-4xl');
+
+    const containerDiv = container.querySelector('.container.mx-auto.max-w-5xl');
     expect(containerDiv).toBeInTheDocument();
-    expect(containerDiv).toHaveClass('py-8');
+    expect(containerDiv).toHaveClass('py-10');
   });
 });

--- a/test/components/CounterContainer.test.tsx
+++ b/test/components/CounterContainer.test.tsx
@@ -115,14 +115,14 @@ describe('CounterContainer', () => {
       const realtimeButton = screen.getByRole('button', { name: /リアルタイムモードに切り替え/i });
       const datetimeButton = screen.getByRole('button', { name: /時間指定モードに切り替え/i });
 
-      // 初期状態（リアルタイムモード選択）
-      expect(realtimeButton.className).toContain('bg-blue-600');
+      // 初期状態（リアルタイムモード選択）- グラデーションスタイル
+      expect(realtimeButton.className).toContain('bg-gradient-to-r');
       expect(realtimeButton.className).toContain('text-white');
 
       // 時間指定モードに切り替え
       fireEvent.click(datetimeButton);
 
-      expect(datetimeButton.className).toContain('bg-blue-600');
+      expect(datetimeButton.className).toContain('bg-gradient-to-r');
       expect(datetimeButton.className).toContain('text-white');
     });
   });

--- a/test/components/DisplayFormatToggle.test.tsx
+++ b/test/components/DisplayFormatToggle.test.tsx
@@ -29,12 +29,12 @@ describe('DisplayFormatToggle', () => {
 
   test('整数表示モードで正しく表示されること', () => {
     render(<DisplayFormatToggle />);
-    
-    expect(screen.getByText('表示形式:')).toBeInTheDocument();
+
+    expect(screen.getByText('表示形式')).toBeInTheDocument();
     expect(screen.getByText('整数')).toBeInTheDocument();
     expect(screen.getByText('小数')).toBeInTheDocument();
     expect(screen.getByText('整数表示（切り捨て）')).toBeInTheDocument();
-    
+
     const toggleButton = screen.getByRole('switch');
     expect(toggleButton).toBeInTheDocument();
     expect(toggleButton).toHaveAttribute('aria-checked', 'true');
@@ -76,31 +76,31 @@ describe('DisplayFormatToggle', () => {
 
   test('適切なCSSクラスが適用されていること', () => {
     render(<DisplayFormatToggle />);
-    
+
     const toggleButton = screen.getByRole('switch');
-    expect(toggleButton).toHaveClass('bg-blue-600', 'border-blue-600');
-    
+    expect(toggleButton).toHaveClass('bg-slate-900', 'border-slate-900');
+
     const integerLabel = screen.getByText('整数');
-    expect(integerLabel).toHaveClass('text-blue-600');
-    
+    expect(integerLabel).toHaveClass('text-slate-900');
+
     const decimalLabel = screen.getByText('小数');
-    expect(decimalLabel).toHaveClass('text-gray-400');
+    expect(decimalLabel).toHaveClass('text-slate-400');
   });
 
   test('小数モード時に適切なCSSクラスが適用されていること', () => {
     mockUseDisplayFormat.format = 'decimal';
     mockUseDisplayFormat.isInteger = false;
     mockUseDisplayFormat.isDecimal = true;
-    
+
     render(<DisplayFormatToggle />);
-    
+
     const toggleButton = screen.getByRole('switch');
-    expect(toggleButton).toHaveClass('bg-gray-200', 'border-gray-300');
-    
+    expect(toggleButton).toHaveClass('bg-white/70', 'border-slate-300');
+
     const integerLabel = screen.getByText('整数');
-    expect(integerLabel).toHaveClass('text-gray-400');
-    
+    expect(integerLabel).toHaveClass('text-slate-400');
+
     const decimalLabel = screen.getByText('小数');
-    expect(decimalLabel).toHaveClass('text-blue-600');
+    expect(decimalLabel).toHaveClass('text-slate-900');
   });
 });

--- a/test/components/Footer.test.tsx
+++ b/test/components/Footer.test.tsx
@@ -13,8 +13,8 @@ describe('Footer', () => {
   test('適切なCSSクラスが適用されていること', () => {
     const { container } = render(<Footer />);
     const footer = container.firstChild as HTMLElement;
-    
-    expect(footer).toHaveClass('bg-gray-50', 'border-t', 'border-gray-200', 'py-6');
+
+    expect(footer).toHaveClass('border-t', 'border-white/70', 'bg-white/70', 'py-6', 'backdrop-blur');
   });
 
   test('コピーライト年が正しく表示されること', () => {

--- a/test/components/Header.test.tsx
+++ b/test/components/Header.test.tsx
@@ -4,14 +4,14 @@ import Header from '@/components/Header';
 describe('Header', () => {
   test('ヘッダーが正しく表示されること', () => {
     render(<Header />);
-    
+
     expect(screen.getByText('地球が何回回った時？')).toBeInTheDocument();
-    expect(screen.getByText('How Many Spins? - 煽りフレーズに即答するWebアプリ')).toBeInTheDocument();
+    expect(screen.getByText(/How Many Spins\? - 煽りフレーズに即答する/)).toBeInTheDocument();
   });
 
   test('適切な見出しレベルが使用されていること', () => {
     render(<Header />);
-    
+
     const h1 = screen.getByRole('heading', { level: 1 });
     expect(h1).toHaveTextContent('地球が何回回った時？');
   });
@@ -19,14 +19,14 @@ describe('Header', () => {
   test('適切なCSSクラスが適用されていること', () => {
     const { container } = render(<Header />);
     const header = container.firstChild as HTMLElement;
-    
-    expect(header).toHaveClass('bg-white', 'shadow-sm', 'border-b', 'border-gray-200', 'py-4');
+
+    expect(header).toHaveClass('border-b', 'border-white/70', 'bg-white/70', 'backdrop-blur');
   });
 
   test('レスポンシブデザインクラスが適用されていること', () => {
     render(<Header />);
-    
+
     const h1 = screen.getByRole('heading', { level: 1 });
-    expect(h1).toHaveClass('text-2xl', 'md:text-4xl', 'font-bold');
+    expect(h1).toHaveClass('text-3xl', 'md:text-5xl', 'font-semibold');
   });
 });

--- a/test/components/MainCounter.test.tsx
+++ b/test/components/MainCounter.test.tsx
@@ -43,23 +43,25 @@ describe('MainCounter', () => {
 
     test('データ読み込み後に正しい内容を表示すること', async () => {
       renderWithProvider(<MainCounter />);
-      
+
       await waitFor(() => {
         expect(screen.getByText('現在時刻')).toBeInTheDocument();
         expect(screen.getByText('地球の累積自転回数')).toBeInTheDocument();
         // デフォルトは整数表示
         expect(screen.getByText('1,234,567 回転')).toBeInTheDocument();
         // 表示形式切り替えトグルが表示されている
-        expect(screen.getByText('表示形式:')).toBeInTheDocument();
+        expect(screen.getByText('表示形式')).toBeInTheDocument();
       });
     });
 
     test('計算基準の説明を表示すること', async () => {
       renderWithProvider(<MainCounter />);
-      
+
       await waitFor(() => {
         expect(screen.getByText(/西暦1年1月1日 00:00 UTC = 0回転/)).toBeInTheDocument();
-        expect(screen.getByText(/恒星日.*基準で計算/)).toBeInTheDocument();
+        // 複数の要素がマッチする可能性があるため、getAllByTextを使用
+        const siderealElements = screen.getAllByText(/恒星日.*基準/);
+        expect(siderealElements.length).toBeGreaterThanOrEqual(1);
       });
     });
 
@@ -95,11 +97,11 @@ describe('MainCounter', () => {
   describe('レスポンシブデザイン', () => {
     test('適切なCSSクラスが適用されていること', async () => {
       renderWithProvider(<MainCounter />);
-      
+
       await waitFor(() => {
         const rotationDisplay = screen.getByText('1,234,567 回転');
         expect(rotationDisplay).toHaveClass('text-3xl', 'md:text-5xl', 'lg:text-6xl');
-        expect(rotationDisplay).toHaveClass('font-bold', 'font-mono');
+        expect(rotationDisplay).toHaveClass('font-semibold', 'font-mono');
       });
     });
   });

--- a/test/integration/app.integration.test.tsx
+++ b/test/integration/app.integration.test.tsx
@@ -13,7 +13,7 @@ describe('App Integration Tests', () => {
     
     // ヘッダーが表示されること
     expect(screen.getByRole('heading', { level: 1, name: '地球が何回回った時？' })).toBeInTheDocument();
-    expect(screen.getByText('How Many Spins? - 煽りフレーズに即答するWebアプリ')).toBeInTheDocument();
+    expect(screen.getByText(/How Many Spins\? - 煽りフレーズに即答する/)).toBeInTheDocument();
     
     // メインカウンターが正しく初期化されること
     await waitFor(() => {
@@ -134,17 +134,17 @@ describe('App Integration Tests', () => {
 
   test('レスポンシブデザインのCSSクラスが正しく適用されていること', async () => {
     render(<HomePage />);
-    
+
     // メイン要素のレスポンシブクラスを確認
     const main = screen.getByRole('main');
     expect(main).toHaveClass('flex-grow');
-    
+
     // ヘッダータイトルのレスポンシブクラスを確認
     await waitFor(() => {
       const title = screen.getByRole('heading', { level: 1, name: '地球が何回回った時？' });
-      expect(title).toHaveClass('text-2xl', 'md:text-4xl', 'font-bold');
+      expect(title).toHaveClass('text-3xl', 'md:text-5xl', 'font-semibold');
     });
-    
+
     // 回転数表示の存在を確認（CSSクラスチェックは省略）
     await waitFor(() => {
       const rotationDisplay = screen.getByText(/\d{1,3}(,\d{3})* 回転/);

--- a/test/integration/datetime-input.integration.test.tsx
+++ b/test/integration/datetime-input.integration.test.tsx
@@ -194,7 +194,7 @@ describe('DateTimeInput 統合テスト', () => {
 
       // 表示形式トグルが表示されていることを確認
       await waitFor(() => {
-        expect(screen.getByText('表示形式:')).toBeInTheDocument();
+        expect(screen.getByText('表示形式')).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
## Summary
- グラスモーフィズムデザインを全体に適用（backdrop-blur, bg-white/70）
- sky-emeraldグラデーションカラーでモダンな印象に統一
- テストを新しいCSSクラスに対応

## 変更内容
### コンポーネント
- **Header**: glassmorphism効果、LIVE COUNTERバッジ追加
- **Footer**: glassmorphism効果
- **MainCounter**: グラデーションテキスト、カード影の更新
- **DateTimeInput**: 新デザインに統一
- **DisplayFormatToggle**: slate配色に変更
- **CounterContainer**: タブボタンのグラデーションスタイル

### テスト
- 新しいCSSクラス名に対応（8ファイル修正）

## Test plan
- [x] `npm run lint` - エラーなし
- [x] `npm run test` - 全162テストパス
- [x] ローカルで動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)