### PR TITLE
feat: 日時プリセット機能の実装 (#15)

### DIFF
--- a/src/components/DateTimeInput.tsx
+++ b/src/components/DateTimeInput.tsx
@@ -5,6 +5,11 @@ import { EarthRotationCalculator } from '@/lib/earth-rotation-calculator';
 import { formatDateTime } from '@/lib/date-formatter';
 import { useDisplayFormat } from '@/hooks/useDisplayFormat';
 import DisplayFormatToggle from './DisplayFormatToggle';
+import {
+  CATEGORY_LABELS,
+  getPresetsByCategory,
+} from '@/lib/datetime-presets';
+import { DateTimePreset } from '@/types/earth-rotation';
 
 interface DateTimeInputValues {
   year: string;
@@ -206,6 +211,33 @@ function DateTimeInput() {
     setError(null);
   }, []);
 
+  /**
+   * プリセット選択時のハンドラ
+   */
+  const handlePresetSelect = useCallback((preset: DateTimePreset) => {
+    setInputValues({
+      year: String(preset.datetime.year),
+      month: String(preset.datetime.month),
+      day: String(preset.datetime.day),
+      hour: String(preset.datetime.hour),
+      minute: String(preset.datetime.minute),
+    });
+    setError(null);
+    setResult(null);
+  }, []);
+
+  /**
+   * カテゴリ別にグループ化されたプリセット
+   */
+  const groupedPresets = useMemo(() => {
+    const categories: DateTimePreset['category'][] = ['era', 'event', 'milestone'];
+    return categories.map((category) => ({
+      category,
+      label: CATEGORY_LABELS[category],
+      presets: getPresetsByCategory(category),
+    }));
+  }, []);
+
   if (!formatLoaded) {
     return (
       <div className="text-center py-12">
@@ -224,6 +256,43 @@ function DateTimeInput() {
         <p className="text-center text-sm text-slate-500 mb-6">
           UTCで入力し、地球の累積自転回数を確認できます
         </p>
+
+        {/* プリセット選択 */}
+        <div className="mb-6">
+          <label className="block text-sm font-semibold text-slate-700 mb-3">
+            プリセットから選択
+          </label>
+          <div className="space-y-3">
+            {groupedPresets.map(({ category, label, presets }) => (
+              <div key={category}>
+                <p className="text-xs font-medium text-slate-500 mb-2">{label}</p>
+                <div className="flex flex-wrap gap-2">
+                  {presets.map((preset) => (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      onClick={() => handlePresetSelect(preset)}
+                      className="rounded-full border border-slate-200/80 bg-white/70 px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-sky-300 hover:bg-sky-50 hover:text-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-300"
+                      title={preset.description}
+                      aria-label={`${preset.label}を選択: ${preset.description}`}
+                    >
+                      {preset.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="relative mb-6">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-slate-200"></div>
+          </div>
+          <div className="relative flex justify-center">
+            <span className="bg-white/80 px-3 text-xs text-slate-500">または直接入力</span>
+          </div>
+        </div>
 
         {/* 入力フォーム */}
         <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/lib/datetime-presets.ts
+++ b/src/lib/datetime-presets.ts
@@ -1,0 +1,153 @@
+import { DateTimePreset } from '@/types/earth-rotation';
+
+/**
+ * 日時プリセットデータ
+ * 歴史的なイベントや元号の始まりなど、よく使われる日時を定義
+ */
+export const DATETIME_PRESETS: DateTimePreset[] = [
+  // 元号カテゴリ
+  {
+    id: 'reiwa-start',
+    label: '令和元年',
+    description: '2019年5月1日 00:00 JST（2019年4月30日 15:00 UTC）',
+    category: 'era',
+    datetime: {
+      year: 2019,
+      month: 4,
+      day: 30,
+      hour: 15,
+      minute: 0,
+    },
+  },
+  {
+    id: 'heisei-start',
+    label: '平成元年',
+    description: '1989年1月8日 00:00 JST（1989年1月7日 15:00 UTC）',
+    category: 'era',
+    datetime: {
+      year: 1989,
+      month: 1,
+      day: 7,
+      hour: 15,
+      minute: 0,
+    },
+  },
+  {
+    id: 'showa-start',
+    label: '昭和元年',
+    description: '1926年12月25日 00:00 JST（1926年12月24日 15:00 UTC）',
+    category: 'era',
+    datetime: {
+      year: 1926,
+      month: 12,
+      day: 24,
+      hour: 15,
+      minute: 0,
+    },
+  },
+  // イベントカテゴリ
+  {
+    id: 'kamakura-1192',
+    label: '鎌倉幕府成立',
+    description: '1192年7月12日 源頼朝が征夷大将軍に就任',
+    category: 'event',
+    datetime: {
+      year: 1192,
+      month: 7,
+      day: 12,
+      hour: 0,
+      minute: 0,
+    },
+  },
+  {
+    id: 'y2k',
+    label: '2000年問題',
+    description: '2000年1月1日 00:00 UTC',
+    category: 'event',
+    datetime: {
+      year: 2000,
+      month: 1,
+      day: 1,
+      hour: 0,
+      minute: 0,
+    },
+  },
+  {
+    id: 'tokyo-olympics-2020',
+    label: '東京五輪2020開会式',
+    description: '2021年7月23日 20:00 JST（11:00 UTC）',
+    category: 'event',
+    datetime: {
+      year: 2021,
+      month: 7,
+      day: 23,
+      hour: 11,
+      minute: 0,
+    },
+  },
+  {
+    id: 'moon-landing',
+    label: '月面着陸（アポロ11号）',
+    description: '1969年7月20日 20:17 UTC',
+    category: 'event',
+    datetime: {
+      year: 1969,
+      month: 7,
+      day: 20,
+      hour: 20,
+      minute: 17,
+    },
+  },
+  // マイルストーンカテゴリ
+  {
+    id: 'unix-epoch',
+    label: 'UNIXエポック',
+    description: '1970年1月1日 00:00 UTC',
+    category: 'milestone',
+    datetime: {
+      year: 1970,
+      month: 1,
+      day: 1,
+      hour: 0,
+      minute: 0,
+    },
+  },
+  {
+    id: 'millennium',
+    label: '21世紀の始まり',
+    description: '2001年1月1日 00:00 UTC',
+    category: 'milestone',
+    datetime: {
+      year: 2001,
+      month: 1,
+      day: 1,
+      hour: 0,
+      minute: 0,
+    },
+  },
+];
+
+/**
+ * カテゴリ別にプリセットを取得
+ */
+export function getPresetsByCategory(
+  category: DateTimePreset['category']
+): DateTimePreset[] {
+  return DATETIME_PRESETS.filter((preset) => preset.category === category);
+}
+
+/**
+ * IDからプリセットを取得
+ */
+export function getPresetById(id: string): DateTimePreset | undefined {
+  return DATETIME_PRESETS.find((preset) => preset.id === id);
+}
+
+/**
+ * カテゴリの日本語ラベル
+ */
+export const CATEGORY_LABELS: Record<DateTimePreset['category'], string> = {
+  era: '元号',
+  event: 'イベント',
+  milestone: 'マイルストーン',
+};

--- a/src/lib/datetime-presets.ts
+++ b/src/lib/datetime-presets.ts
@@ -98,6 +98,19 @@ export const DATETIME_PRESETS: DateTimePreset[] = [
       minute: 17,
     },
   },
+  {
+    id: 'osaka-expo-2025',
+    label: '大阪・関西万博開幕',
+    description: '2025年4月13日 10:00 JST（01:00 UTC）',
+    category: 'event',
+    datetime: {
+      year: 2025,
+      month: 4,
+      day: 13,
+      hour: 1,
+      minute: 0,
+    },
+  },
   // マイルストーンカテゴリ
   {
     id: 'unix-epoch',

--- a/src/types/earth-rotation.ts
+++ b/src/types/earth-rotation.ts
@@ -41,3 +41,25 @@ export interface AppState {
   /** 最終更新時刻 */
   lastUpdateTime: number;
 }
+
+/**
+ * 日時プリセットの型定義
+ */
+export interface DateTimePreset {
+  /** プリセットID */
+  id: string;
+  /** 表示名 */
+  label: string;
+  /** 説明文 */
+  description: string;
+  /** カテゴリ */
+  category: 'era' | 'event' | 'milestone';
+  /** 日時データ（UTC） */
+  datetime: {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+  };
+}

--- a/test/components/DateTimeInput.test.tsx
+++ b/test/components/DateTimeInput.test.tsx
@@ -300,6 +300,113 @@ describe('DateTimeInput', () => {
     });
   });
 
+  describe('プリセット機能', () => {
+    test('プリセット選択UIが表示されること', async () => {
+      renderWithProvider(<DateTimeInput />);
+
+      await waitFor(() => {
+        expect(screen.getByText('プリセットから選択')).toBeInTheDocument();
+        expect(screen.getByText('元号')).toBeInTheDocument();
+        expect(screen.getByText('イベント')).toBeInTheDocument();
+        expect(screen.getByText('マイルストーン')).toBeInTheDocument();
+      });
+    });
+
+    test('プリセットボタンが表示されること', async () => {
+      renderWithProvider(<DateTimeInput />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /令和元年を選択/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /平成元年を選択/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /2000年問題を選択/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /UNIXエポックを選択/i })).toBeInTheDocument();
+      });
+    });
+
+    test('プリセットをクリックすると入力値が反映されること', async () => {
+      renderWithProvider(<DateTimeInput />);
+
+      await waitFor(() => {
+        // 令和元年を選択（2019年4月30日 15:00 UTC）
+        const reiwaButton = screen.getByRole('button', { name: /令和元年を選択/i });
+        fireEvent.click(reiwaButton);
+
+        const yearInput = screen.getByLabelText('年') as HTMLInputElement;
+        const monthInput = screen.getByLabelText('月') as HTMLInputElement;
+        const dayInput = screen.getByLabelText('日') as HTMLInputElement;
+        const hourInput = screen.getByLabelText('時') as HTMLInputElement;
+        const minuteInput = screen.getByLabelText('分') as HTMLInputElement;
+
+        expect(yearInput.value).toBe('2019');
+        expect(monthInput.value).toBe('4');
+        expect(dayInput.value).toBe('30');
+        expect(hourInput.value).toBe('15');
+        expect(minuteInput.value).toBe('0');
+      });
+    });
+
+    test('別のプリセットを選択すると入力値が更新されること', async () => {
+      renderWithProvider(<DateTimeInput />);
+
+      await waitFor(() => {
+        // 令和元年を選択
+        const reiwaButton = screen.getByRole('button', { name: /令和元年を選択/i });
+        fireEvent.click(reiwaButton);
+
+        // UNIXエポックを選択（1970年1月1日 00:00 UTC）
+        const unixButton = screen.getByRole('button', { name: /UNIXエポックを選択/i });
+        fireEvent.click(unixButton);
+
+        const yearInput = screen.getByLabelText('年') as HTMLInputElement;
+        const monthInput = screen.getByLabelText('月') as HTMLInputElement;
+        const dayInput = screen.getByLabelText('日') as HTMLInputElement;
+
+        expect(yearInput.value).toBe('1970');
+        expect(monthInput.value).toBe('1');
+        expect(dayInput.value).toBe('1');
+      });
+    });
+
+    test('プリセット選択後にエラーがクリアされること', async () => {
+      renderWithProvider(<DateTimeInput />);
+
+      await waitFor(async () => {
+        // エラーを発生させる
+        const calculateButton = screen.getByRole('button', { name: /計算する/i });
+        fireEvent.click(calculateButton);
+
+        await waitFor(() => {
+          expect(screen.getByText('すべての項目を入力してください')).toBeInTheDocument();
+        });
+
+        // プリセットを選択
+        const reiwaButton = screen.getByRole('button', { name: /令和元年を選択/i });
+        fireEvent.click(reiwaButton);
+
+        expect(screen.queryByText('すべての項目を入力してください')).not.toBeInTheDocument();
+      });
+    });
+
+    test('プリセット選択後に計算できること', async () => {
+      renderWithProvider(<DateTimeInput />);
+
+      await waitFor(async () => {
+        // 令和元年を選択
+        const reiwaButton = screen.getByRole('button', { name: /令和元年を選択/i });
+        fireEvent.click(reiwaButton);
+
+        // 計算実行
+        const calculateButton = screen.getByRole('button', { name: /計算する/i });
+        fireEvent.click(calculateButton);
+
+        await waitFor(() => {
+          expect(mockCalculateRotationsFromDate).toHaveBeenCalled();
+          expect(screen.getByText('計算結果')).toBeInTheDocument();
+        });
+      });
+    });
+  });
+
   // ヘルパー関数
   function fillAllFields({ year, month, day, hour, minute }: {
     year: string;

--- a/test/integration/datetime-input.integration.test.tsx
+++ b/test/integration/datetime-input.integration.test.tsx
@@ -242,6 +242,91 @@ describe('DateTimeInput 統合テスト', () => {
     });
   });
 
+  describe('プリセット機能の統合テスト', () => {
+    test('プリセット選択から計算までの一連の流れが正常に動作すること', async () => {
+      renderWithProvider(<CounterContainer />);
+
+      // 時間指定モードに切り替え
+      await waitFor(() => {
+        const datetimeButton = screen.getByRole('button', { name: /時間指定モードに切り替え/i });
+        fireEvent.click(datetimeButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('プリセットから選択')).toBeInTheDocument();
+      });
+
+      // 令和元年を選択
+      await waitFor(() => {
+        const reiwaButton = screen.getByRole('button', { name: /令和元年を選択/i });
+        fireEvent.click(reiwaButton);
+      });
+
+      // 入力値が反映されていることを確認
+      await waitFor(() => {
+        const yearInput = screen.getByLabelText('年') as HTMLInputElement;
+        expect(yearInput.value).toBe('2019');
+      });
+
+      // 計算を実行
+      await waitFor(() => {
+        const calculateButton = screen.getByRole('button', { name: /計算する/i });
+        fireEvent.click(calculateButton);
+      });
+
+      // 計算結果が表示されることを確認
+      await waitFor(() => {
+        expect(screen.getByText('計算結果')).toBeInTheDocument();
+      });
+    });
+
+    test('プリセット選択後にタブを切り替えて戻ると入力値がリセットされること', async () => {
+      renderWithProvider(<CounterContainer />);
+
+      // 時間指定モードに切り替え
+      await waitFor(() => {
+        const datetimeButton = screen.getByRole('button', { name: /時間指定モードに切り替え/i });
+        fireEvent.click(datetimeButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('プリセットから選択')).toBeInTheDocument();
+      });
+
+      // UNIXエポックを選択
+      await waitFor(() => {
+        const unixButton = screen.getByRole('button', { name: /UNIXエポックを選択/i });
+        fireEvent.click(unixButton);
+      });
+
+      // 入力値が反映されていることを確認
+      await waitFor(() => {
+        const yearInput = screen.getByLabelText('年') as HTMLInputElement;
+        expect(yearInput.value).toBe('1970');
+      });
+
+      // リアルタイムモードに戻す
+      const realtimeButton = screen.getByRole('button', { name: /リアルタイムモードに切り替え/i });
+      fireEvent.click(realtimeButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('地球の累積自転回数')).toBeInTheDocument();
+      });
+
+      // 再度時間指定モードに切り替え
+      await waitFor(() => {
+        const datetimeButton = screen.getByRole('button', { name: /時間指定モードに切り替え/i });
+        fireEvent.click(datetimeButton);
+      });
+
+      // 入力値がリセットされていることを確認
+      await waitFor(() => {
+        const yearInput = screen.getByLabelText('年') as HTMLInputElement;
+        expect(yearInput.value).toBe('');
+      });
+    });
+  });
+
   // ヘルパー関数
   function fillAllFields({ year, month, day, hour, minute }: {
     year: string;

--- a/test/lib/datetime-presets.test.ts
+++ b/test/lib/datetime-presets.test.ts
@@ -1,0 +1,130 @@
+import {
+  DATETIME_PRESETS,
+  CATEGORY_LABELS,
+  getPresetsByCategory,
+  getPresetById,
+} from '@/lib/datetime-presets';
+
+describe('datetime-presets', () => {
+  describe('DATETIME_PRESETS', () => {
+    test('プリセットが定義されていること', () => {
+      expect(DATETIME_PRESETS.length).toBeGreaterThan(0);
+    });
+
+    test('各プリセットが必須フィールドを持つこと', () => {
+      DATETIME_PRESETS.forEach((preset) => {
+        expect(preset.id).toBeDefined();
+        expect(preset.label).toBeDefined();
+        expect(preset.description).toBeDefined();
+        expect(preset.category).toBeDefined();
+        expect(preset.datetime).toBeDefined();
+        expect(preset.datetime.year).toBeDefined();
+        expect(preset.datetime.month).toBeDefined();
+        expect(preset.datetime.day).toBeDefined();
+        expect(preset.datetime.hour).toBeDefined();
+        expect(preset.datetime.minute).toBeDefined();
+      });
+    });
+
+    test('各プリセットのIDが一意であること', () => {
+      const ids = DATETIME_PRESETS.map((preset) => preset.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    test('日時の値が有効な範囲内であること', () => {
+      DATETIME_PRESETS.forEach((preset) => {
+        const { year, month, day, hour, minute } = preset.datetime;
+        expect(year).toBeGreaterThanOrEqual(1);
+        expect(year).toBeLessThanOrEqual(9999);
+        expect(month).toBeGreaterThanOrEqual(1);
+        expect(month).toBeLessThanOrEqual(12);
+        expect(day).toBeGreaterThanOrEqual(1);
+        expect(day).toBeLessThanOrEqual(31);
+        expect(hour).toBeGreaterThanOrEqual(0);
+        expect(hour).toBeLessThanOrEqual(23);
+        expect(minute).toBeGreaterThanOrEqual(0);
+        expect(minute).toBeLessThanOrEqual(59);
+      });
+    });
+  });
+
+  describe('CATEGORY_LABELS', () => {
+    test('全カテゴリのラベルが定義されていること', () => {
+      expect(CATEGORY_LABELS.era).toBe('元号');
+      expect(CATEGORY_LABELS.event).toBe('イベント');
+      expect(CATEGORY_LABELS.milestone).toBe('マイルストーン');
+    });
+  });
+
+  describe('getPresetsByCategory', () => {
+    test('元号カテゴリのプリセットを取得できること', () => {
+      const eraPresets = getPresetsByCategory('era');
+      expect(eraPresets.length).toBeGreaterThan(0);
+      eraPresets.forEach((preset) => {
+        expect(preset.category).toBe('era');
+      });
+    });
+
+    test('イベントカテゴリのプリセットを取得できること', () => {
+      const eventPresets = getPresetsByCategory('event');
+      expect(eventPresets.length).toBeGreaterThan(0);
+      eventPresets.forEach((preset) => {
+        expect(preset.category).toBe('event');
+      });
+    });
+
+    test('マイルストーンカテゴリのプリセットを取得できること', () => {
+      const milestonePresets = getPresetsByCategory('milestone');
+      expect(milestonePresets.length).toBeGreaterThan(0);
+      milestonePresets.forEach((preset) => {
+        expect(preset.category).toBe('milestone');
+      });
+    });
+  });
+
+  describe('getPresetById', () => {
+    test('存在するIDでプリセットを取得できること', () => {
+      const preset = getPresetById('reiwa-start');
+      expect(preset).toBeDefined();
+      expect(preset?.label).toBe('令和元年');
+    });
+
+    test('存在しないIDの場合はundefinedを返すこと', () => {
+      const preset = getPresetById('non-existent-id');
+      expect(preset).toBeUndefined();
+    });
+  });
+
+  describe('具体的なプリセットデータの検証', () => {
+    test('令和元年のデータが正しいこと', () => {
+      const preset = getPresetById('reiwa-start');
+      expect(preset).toBeDefined();
+      expect(preset?.datetime.year).toBe(2019);
+      expect(preset?.datetime.month).toBe(4);
+      expect(preset?.datetime.day).toBe(30);
+      expect(preset?.datetime.hour).toBe(15);
+      expect(preset?.datetime.minute).toBe(0);
+    });
+
+    test('2000年問題のデータが正しいこと', () => {
+      const preset = getPresetById('y2k');
+      expect(preset).toBeDefined();
+      expect(preset?.datetime.year).toBe(2000);
+      expect(preset?.datetime.month).toBe(1);
+      expect(preset?.datetime.day).toBe(1);
+      expect(preset?.datetime.hour).toBe(0);
+      expect(preset?.datetime.minute).toBe(0);
+    });
+
+    test('UNIXエポックのデータが正しいこと', () => {
+      const preset = getPresetById('unix-epoch');
+      expect(preset).toBeDefined();
+      expect(preset?.datetime.year).toBe(1970);
+      expect(preset?.datetime.month).toBe(1);
+      expect(preset?.datetime.day).toBe(1);
+      expect(preset?.datetime.hour).toBe(0);
+      expect(preset?.datetime.minute).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 過去の特定イベント日時を簡単に入力できるプリセット機能を実装
- 元号（令和、平成、昭和）、歴史的イベント（鎌倉幕府成立、月面着陸、東京五輪2020等）、マイルストーン（UNIXエポック、21世紀の始まり）のカテゴリを追加
- プリセットボタンをクリックすると入力フィールドに自動入力される

## Changes
- `src/types/earth-rotation.ts`: DateTimePreset型を追加
- `src/lib/datetime-presets.ts`: プリセットデータと関連ユーティリティ関数を追加
- `src/components/DateTimeInput.tsx`: プリセット選択UIを追加
- ユニットテストと統合テストを追加（テストカバレッジ維持）

## Test plan
- [x] `npm run lint` - エラーなし
- [x] `npm run test` - 184テスト全て合格
- [x] `npm run build` - ビルド成功
- [ ] ブラウザでプリセット選択機能の動作確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)